### PR TITLE
Fix docker build by using rustup from nixpkgs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,12 +6,9 @@ ENV RUSTUP_HOME=/usr/local/rustup \
 
 RUN wget "https://raw.githubusercontent.com/TrueDoctor/ratatosk/master/shell.nix"; \
     nix-shell; \
-    nix-env -i libgcc; \
-    url="https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-musl/rustup-init"; \
-    wget "$url"; \
-    chmod +x rustup-init; \
-    ./rustup-init -y --no-modify-path --default-toolchain nightly-2020-02-17; \
-    rm rustup-init; \
+    nix-env -iA nixpkgs.rustup; \
+    rustup install nightly-2020-02-17; \
+    rustup default nightly-2020-02-17; \
     rustup target add wasm32-unknown-unknown; \
     chmod -R a+w $RUSTUP_HOME $CARGO_HOME; \
     rustup --version; \


### PR DESCRIPTION
This has a patch that properly patches ELF-headers of its components.